### PR TITLE
Replace `sklearn` dependency with `scikit-learn`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ python_requires = >= 3.6
 spacy = 
     spacy
 sklearn =
-    sklearn
+    scikit-learn
 test = 
     pytest
     tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = rasa-converter
-version = 0.0.1
+version = 0.0.2
 author = Nick Sorros
 author_email = nsorros@gmail.com
 description = Converts Rasa data to other formats


### PR DESCRIPTION
Install `sklearn` is now deprecated, this switches to `scikit-learn`.
